### PR TITLE
Fix retrieval of remapped method names

### DIFF
--- a/Minecraft-Reflection/src/main/java/com/captainbern/minecraft/reflection/providers/remapper/RemappedReflectionProvider.java
+++ b/Minecraft-Reflection/src/main/java/com/captainbern/minecraft/reflection/providers/remapper/RemappedReflectionProvider.java
@@ -101,7 +101,7 @@ public class RemappedReflectionProvider extends StandardReflectionProvider {
         for (Map.Entry<String, String> entry : this.methods.entrySet()) {
             if (entry.getKey().startsWith(path)) {
                 try {
-                    type.getDeclaredMethod(name, args);
+                    type.getDeclaredMethod(entry.getValue(), args);
 
                     return entry.getValue();
                 } catch (NoSuchMethodException e) {


### PR DESCRIPTION
If I understand correctly, this should be testing against the remapped name, not the original name. It should work better that way :3.

Feel free to slap me if I'm wrong.
